### PR TITLE
Remove dependence of RidgeTrack on explicit index ordering of DNA Accessibility data

### DIFF
--- a/src/components/custom-tracks/ridge-plot-track.tsx
+++ b/src/components/custom-tracks/ridge-plot-track.tsx
@@ -472,6 +472,7 @@ const createRidgePlotTrack = function createRidgePlotTrack(
       if (
         JSON.stringify(this.rowCategories) !== JSON.stringify(oldRowCategories)
       ) {
+        this.updateRowSelectionIndices();
         this.updateRowLabels();
         this.drawLabel();
       }

--- a/src/components/dna-accessibility/DnaAccessibility.tsx
+++ b/src/components/dna-accessibility/DnaAccessibility.tsx
@@ -1,3 +1,11 @@
+/**
+ * @fileoverview
+ * Renders the DNA accessibility of all cell samples in a stratified fashion
+ * using ridge plots.
+ *
+ * Modifications to the RidgePlotTrack are done by editing the track's options
+ * in the ViewConfig.
+ */
 import React, { useCallback, useEffect, useMemo, useRef } from 'react';
 import { useRecoilValue, useSetRecoilState } from 'recoil';
 import Grid from '@material-ui/core/Grid';
@@ -26,10 +34,7 @@ import {
 import { focusRegionAbsWithAssembly } from '../../state/focus-state';
 import { variantTracksState } from '../../state/variant-track-state';
 
-import {
-  DEFAULT_DNA_ACCESSIBILITY_ROW_SELECTION,
-  DEFAULT_VIEW_CONFIG_DNA_ACCESSIBILITY,
-} from './constants-dna-accessibility';
+import { DEFAULT_VIEW_CONFIG_DNA_ACCESSIBILITY } from './constants-dna-accessibility';
 import useDebounce from '../../hooks/use-debounce';
 
 import {
@@ -86,15 +91,12 @@ const updateViewConfigDnaAccessRowNorm =
   };
 
 const updateViewConfigRowSelection =
-  (selection: boolean[]) => (viewConfig: ViewConfig) => {
+  (selection: string[]) => (viewConfig: ViewConfig) => {
     const track = getTrackByUid(
       viewConfig,
       'dna-accessibility'
     ) as RidgePlotTrack;
-    track.options.rowSelections =
-      DEFAULT_DNA_ACCESSIBILITY_ROW_SELECTION.filter(
-        (rowId, i) => selection[i]
-      );
+    track.options.rowSelections = selection;
     return viewConfig;
   };
 

--- a/src/components/dna-accessibility/constants-dna-accessibility.ts
+++ b/src/components/dna-accessibility/constants-dna-accessibility.ts
@@ -139,7 +139,6 @@ export const DEFAULT_VIEW_CONFIG_DNA_ACCESSIBILITY: ViewConfig = {
               rowHeight: 24,
               rowPadding: -6,
               rowNormalization: true,
-              rowSelections: DEFAULT_DNA_ACCESSIBILITY_ROW_SELECTION,
               rowIdToCategory: {
                 fn: 'replace',
                 args: ['.accessibility', ''],
@@ -150,6 +149,7 @@ export const DEFAULT_VIEW_CONFIG_DNA_ACCESSIBILITY: ViewConfig = {
               showMousePosition: true,
               showGlobalMousePosition: true,
               mousePositionColor: 'black',
+              // rowSelections set automatically via DnaAccessibility
             },
           },
         ],

--- a/src/components/dna-accessibility/constants-dna-accessibility.ts
+++ b/src/components/dna-accessibility/constants-dna-accessibility.ts
@@ -10,17 +10,6 @@ import { createCategoryMap } from './dna-accessibility-fns';
 export const DEFAULT_DNA_ACCESSIBILITY_ROW_CATEGORIES: CategoryNameToDnaAccessibilityCategoryMap =
   createCategoryMap(DEFAULT_STRATIFICATION);
 
-export const DEFAULT_DNA_ACCESSIBILITY_ROW_SELECTION = [
-  120, 36, 54, 20, 80, 35, 101, 49, 44, 23, 30, 66, 5, 26, 15, 105, 57, 56, 74,
-  84, 79, 93, 106, 107, 34, 28, 25, 55, 121, 94, 58, 69, 67, 63, 126, 71, 72,
-  47, 11, 46, 39, 113, 29, 60, 45, 76, 21, 103, 129, 13, 128, 90, 104, 32, 109,
-  27, 9, 130, 95, 86, 53, 73, 50, 48, 78, 14, 92, 124, 31, 114, 64, 88, 12, 10,
-  38, 68, 3, 111, 70, 22, 61, 98, 6, 123, 118, 43, 37, 65, 81, 62, 33, 1, 24,
-  122, 83, 75, 112, 40, 97, 16, 117, 87, 19, 125, 7, 102, 116, 77, 8, 17, 82,
-  115, 89, 119, 18, 4, 108, 59, 127, 91, 0, 100, 85, 110, 99, 2, 96, 51, 41, 52,
-  42,
-];
-
 export const DEFAULT_VIEW_CONFIG_DNA_ACCESSIBILITY: ViewConfig = {
   zoomFixed: false,
   editable: false,
@@ -149,7 +138,7 @@ export const DEFAULT_VIEW_CONFIG_DNA_ACCESSIBILITY: ViewConfig = {
               showMousePosition: true,
               showGlobalMousePosition: true,
               mousePositionColor: 'black',
-              // rowSelections set automatically via DnaAccessibility
+              // rowSelections set automatically via DnaAccessibility on construction
             },
           },
         ],

--- a/src/state/filter-state.ts
+++ b/src/state/filter-state.ts
@@ -31,7 +31,7 @@ export const sampleWithName = memoize((name: string) =>
 export const sampleSelectionState = selector({
   key: 'sampleSelection',
   get: ({ get }) =>
-    samples(get(stratificationState)).map(
+    samples(get(stratificationState)).filter(
       (name) => get(sampleWithName(name)).checked
     ),
 });

--- a/src/types/higlass.d.ts
+++ b/src/types/higlass.d.ts
@@ -199,13 +199,21 @@ declare module '@higlass/tracks' {
   export class _Track {
     /* Properites */
     id: string;
+
     _xScale: Scale;
+
     _yScale: Scale;
+
     _refXScale: Scale;
+
     _refYScale: Scale;
+
     position: [number, number];
+
     dimensions: [number, number];
+
     options: TrackOptions;
+
     pubSubs: Subscription[];
     /* Constructor */
     constructor(props: { id: string; pubSub: PubSub; getTheme?: () => string });
@@ -250,25 +258,45 @@ declare module '@higlass/tracks' {
   export class PixiTrack<Options extends TrackOptions> extends _Track {
     /* Properties */
     delayDrawing: boolean;
+
     scene: PIXI.Graphics;
+
     pBase: PIXI.Graphics;
+
     pMasked: PIXI.Graphics;
+
     pMask: PIXI.Graphics;
+
     pMain: PIXI.Graphics;
+
     pBorder: PIXI.Graphics;
+
     pBackground: PIXI.Graphics;
+
     pForeground: PIXI.Graphics;
+
     pLabel: PIXI.Graphics;
+
     pMobile: PIXI.Graphics;
+
     pAxis: PIXI.Graphics;
+
     pMouseOver: PIXI.Graphics;
+
     options: Options;
+
     labelTextFontFamily: string;
+
     labelTextFontSize: number;
+
     labelXOffset: number;
+
     labelText: PIXI.Text;
+
     errorText: PIXI.Text;
+
     prevOptions: string;
+
     flipText?: boolean; // Property never assigned https://github.com/higlass/higlass/blob/develop/app/scripts/PixiTrack.js
     /* Constructor */
     constructor(context: Context<Options>, options: Options);
@@ -290,33 +318,61 @@ declare module '@higlass/tracks' {
   > extends PixiTrack<Options> {
     constructor(context: Context<Options>, options: Options);
     renderVersion: number;
+
     visibleTiles: Set<any>;
+
     visibleTileIds: Set<string>;
+
     renderingTiles: Set<any>;
+
     fetching: Set<any>;
+
     scale: {};
+
     fetchedTiles: { [key: string]: HiGlassTile };
+
     tileGraphics: {};
+
     maxZoom: number;
+
     medianVisibleValue: any;
+
     backgroundTaskScheduler: import('./utils/background-task-scheduler').BackgroundTaskScheduler;
+
     continuousScaling: boolean;
+
     valueScaleMin: number;
+
     fixedValueScaleMin: number;
+
     valueScaleMax: number;
+
     fixedValueScaleMax: number;
+
     listeners: {};
+
     animate: any;
+
     onValueScaleChanged: any;
+
     prevValueScale: any;
+
     dataFetcher: any;
+
     tilesetInfo: TilesetInfo;
+
     uuid: any;
+
     trackNotFoundText: PIXI.Text;
+
     refreshTilesDebounced: Function;
+
     tilesetUid: any;
+
     server: any;
+
     chromInfo: any;
+
     setError(error: any): void;
     errorTextText: any;
     setFixedValueScaleMin(value: any): void;
@@ -421,8 +477,11 @@ declare module '@higlass/tracks' {
   > extends TiledPixiTrack<Options> {
     constructor(context: Context<Options>, options: Options);
     onMouseMoveZoom: any;
+
     isValueScaleLocked: any;
+
     getLockGroupExtrema: any;
+
     initTile(tile: any): void;
     tileToLocalId(tile: any): string;
     tileToRemoteId(tile: any): string;
@@ -430,6 +489,7 @@ declare module '@higlass/tracks' {
     setVisibleTiles(tilePositions: any): void;
     calculateVisibleTiles(): void;
     zoomLevel: any;
+
     getTilePosAndDimensions(
       zoomLevel: any,
       tilePos: any,
@@ -468,6 +528,7 @@ declare module '@higlass/tracks' {
     getDataAtPos(relPos: number): number;
     mouseMoveHandler({ x, y }?: { x: any; y: any }): void;
     mouseX: any;
+
     mouseY: any;
     mouseMoveZoomHandler(): void;
     zoomed(...args: any[]): void;
@@ -478,8 +539,11 @@ declare module '@higlass/tracks' {
   > extends Tiled1DPixiTrack<Options> {
     constructor(context: Context<Options>, options: Options);
     constIndicator: PIXI.Graphics;
+
     axis: AxisPixi;
+
     isShowGlobalMousePosition: any;
+
     hideMousePosition: Function;
     rerender(options: any, force: any): void;
     calculateZoomLevel(): any;
@@ -613,6 +677,7 @@ declare module '@higlass/utils' {
   export class DenseDataExtrema1D {
     constructor(arr: ArrayLike<number | null>);
     minNonZeroInTile: number;
+
     maxNonZeroInTile: number;
   }
   export const trackUtils: {

--- a/src/utils/string.ts
+++ b/src/utils/string.ts
@@ -3,7 +3,7 @@ export function capitalizeFirstLetter(s: string) {
 }
 
 export function getMethodsMap(obj: any): { [key: string]: Function } {
-  let properties = new Set<string>();
+  const properties = new Set<string>();
   let currentObj = obj;
   do {
     Object.getOwnPropertyNames(currentObj).map((item) => properties.add(item));

--- a/src/view-config-types.ts
+++ b/src/view-config-types.ts
@@ -361,7 +361,7 @@ export type RidgePlotTrackOptions = {
   rowHeight?: number;
   rowPadding?: number;
   rowNormalization?: boolean;
-  rowSelections?: number[];
+  rowSelections?: string[];
   rowIdToCategory: {
     fn: string;
     args: [string, string];


### PR DESCRIPTION
**State Before**
DNA accessibility component passes an explicit `number[]` that tells the RidgePlot track which indices of TileData to render in order. This numeric array must be manually maintained and does not scale to different orderings or selections, since DNA accessibility only modifies the original constant array by filtering values from it.

**State Now**
DNA accessibility component constructs a `string[]` of the cell sample names in order, from the existing cell stratification view configuration (thus keeping them in sync). The RidgePlot will use the order of sample names to match to the tileset data fetched, and appropriately construct the ordering for the data to display.